### PR TITLE
fix: Update chromium.connect call and add logging

### DIFF
--- a/haxball.mjs
+++ b/haxball.mjs
@@ -88,10 +88,11 @@ export async function start(token) {
         throw new Error(errorMsg);
     }
 
+    console.log(`Attempting to connect to Playwright server at: ${wsPath}`);
     updateState({ status: 'starting', status_message: 'Connecting to Playwright server...' });
 
     try {
-        const browser = await chromium.connect(wsPath, { timeout: 20000 });
+        const browser = await chromium.connect({ wsEndpoint: wsPath, timeout: 20000 });
         updateState({ browser, status_message: 'Connected to Playwright. Opening new page...' });
 
         const context = await browser.newContext();


### PR DESCRIPTION
The `playwright.chromium.connect` method signature has been updated in recent versions of Playwright. The previous code was using an outdated signature, passing the WebSocket endpoint and options as separate arguments. This caused a `400 Bad Request` error when connecting to the Playwright server.

This commit updates the call to use a single options object, passing the WebSocket endpoint as the `wsEndpoint` property. This aligns the code with the modern Playwright API and resolves the connection error.

Additionally, a log statement has been added to display the WebSocket path before the connection attempt, which will aid in future debugging.