### PR TITLE
feat: Add basic authentication to the server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     # This should match the WS_PATH used by your playwright-server.
     environment:
       - WS_PATH=${WS_PATH}
+      - USERNAME=${USERNAME}
+      - PASSWORD=${PASSWORD}
     ports:
       - "5010:8080"
 

--- a/server.mjs
+++ b/server.mjs
@@ -19,6 +19,26 @@ function sendStateToAllClients() {
 setStateUpdateCallback(sendStateToAllClients);
 
 const server = http.createServer(async (req, res) => {
+    // Simple Basic Authentication
+    const { USERNAME, PASSWORD } = process.env;
+    if (USERNAME && PASSWORD) {
+        const authHeader = req.headers['authorization'];
+        if (!authHeader || !authHeader.startsWith('Basic ')) {
+            res.writeHead(401, { 'WWW-Authenticate': 'Basic realm="Restricted Area"' });
+            res.end('Authentication required.');
+            return;
+        }
+
+        const credentials = Buffer.from(authHeader.split(' ')[1], 'base64').toString();
+        const [username, password] = credentials.split(':');
+
+        if (username !== USERNAME || password !== PASSWORD) {
+            res.writeHead(401, { 'WWW-Authenticate': 'Basic realm="Restricted Area"' });
+            res.end('Invalid credentials.');
+            return;
+        }
+    }
+
     const parsedUrl = url.parse(req.url, true);
     const pathname = parsedUrl.pathname;
 


### PR DESCRIPTION
This commit introduces a Basic Authentication layer to protect the server's endpoints.

- The authentication is enabled by setting the `USERNAME` and `PASSWORD` environment variables. If they are not set, the server remains accessible without authentication.
- All HTTP requests (including for the admin page, API endpoints, and SSE stream) are protected when authentication is enabled.
- The `docker-compose.yml` file has been updated to allow passing these environment variables to the container, similar to the existing `WS_PATH` variable.