### PR TITLE
Trigger deploy GitHub Action on master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
### Motivation
- Update the deploy workflow to run on pushes to `master` instead of `main` so deployments trigger from the repository's primary branch.

### Description
- Change `.github/workflows/deploy.yml` to replace `- main` with `- master` under `on: push: branches:`.

### Testing
- No automated tests were run because this is a workflow configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141d53f8c48333b5cece1ae720a821)