### PR TITLE
Allow backup management endpoints to work while room is stopped

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -3,11 +3,21 @@ import fs from 'fs';
 import url from 'url';
 import path from 'path';
 import { start, stop, getRoomState, setStateUpdateCallback, getStatsTracker } from './haxball.mjs';
+import { StatsDatabase } from './stats/index.mjs';
 
 const PORT = process.env.PORT || 8080;
 
 // Array to hold connected SSE clients
 let clients = [];
+let backupDb = null;
+
+async function getBackupDatabase() {
+    if (!backupDb) {
+        backupDb = new StatsDatabase('./data/stats.db');
+        await backupDb.connect();
+    }
+    return backupDb;
+}
 
 // Function to send the current state to all connected clients
 function sendStateToAllClients() {
@@ -199,12 +209,8 @@ const server = http.createServer(async (req, res) => {
         (async () => {
             try {
                 const statsTracker = getStatsTracker();
-                if (!statsTracker) {
-                    res.writeHead(400, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ message: "Stats tracker not initialized. Start the room first." }));
-                    return;
-                }
-                const backups = statsTracker.db.listBackups();
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                const backups = db.listBackups();
                 res.writeHead(200, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify(backups));
             } catch (error) {
@@ -232,13 +238,8 @@ const server = http.createServer(async (req, res) => {
                 }
 
                 const statsTracker = getStatsTracker();
-                if (!statsTracker) {
-                    res.writeHead(400, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ message: "Stats tracker not initialized. Start the room first." }));
-                    return;
-                }
-
-                const result = await statsTracker.db.restoreBackup(filename);
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                const result = await db.restoreBackup(filename);
                 res.writeHead(200, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ message: result.message, restoredFrom: result.restoredFrom }));
             } catch (error) {
@@ -257,13 +258,8 @@ const server = http.createServer(async (req, res) => {
                 }
 
                 const statsTracker = getStatsTracker();
-                if (!statsTracker) {
-                    res.writeHead(400, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ message: "Stats tracker not initialized." }));
-                    return;
-                }
-
-                const backups = statsTracker.db.listBackups();
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                const backups = db.listBackups();
                 const backup = backups.find(b => b.filename === file);
 
                 if (!backup) {


### PR DESCRIPTION
### Motivation
- Backup listing/downloading/restoring previously failed when the in-memory stats tracker was not initialized, which made backups inaccessible while the room was stopped.  
- The intent is to allow backup operations to work even when the room process is not running while still preventing restores when the room is active.

### Description
- Import `StatsDatabase` and add a cached `backupDb` plus a lazy `getBackupDatabase()` helper that calls `connect()` to open `./data/stats.db` when needed.  
- Update `/list-backups` to use `statsTracker.db` when available or fall back to `await getBackupDatabase()` and call `listBackups()`.  
- Update `/restore-backup` and `/download-backup` to similarly use the active room DB when present or the fallback DB, while preserving the check that restore is only allowed when `getRoomState().status === 'stopped'`.

### Testing
- Ran `node --check server.mjs` to validate the server file syntax and it succeeded.  
- Verified the repository status and created PR metadata via the provided `make_pr` helper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143c66d9148333b07f9a5ba24bbf40)