### PR TITLE
Add Merge Players and Danger Zone admin UIs with server and DB support

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -21,7 +21,9 @@
     <h1>Haxball Admin Panel</h1>
 
     <div style="margin-bottom: 1.5em; padding-bottom: 1em; border-bottom: 1px solid #ddd;">
-        <a href="/backups" style="color: #007bff; text-decoration: none; font-size: 0.95em;">📦 Manage Backups</a>
+        <a href="/backups" style="color: #007bff; text-decoration: none; font-size: 0.95em; margin-right: 1em;">📦 Manage Backups</a>
+        <a href="/merge-players" style="color: #007bff; text-decoration: none; font-size: 0.95em; margin-right: 1em;">🔀 Merge Players</a>
+        <a href="/danger-zone" style="color: #dc3545; text-decoration: none; font-size: 0.95em;">⚠️ Danger Zone</a>
     </div>
 
     <div id="status">
@@ -52,18 +54,6 @@
         </div>
     </div>
 
-    <div id="danger-zone" style="margin-top: 2em; padding: 1em; border: 2px solid #dc3545; border-radius: 5px; background-color: #fff5f5;">
-        <h3 style="color: #dc3545;">Danger Zone</h3>
-        <p>Permanently delete all statistics from the database. This action cannot be undone.</p>
-        <button type="button" id="clear-stats-btn" style="background-color: #dc3545; color: white; border: none;">Clear Database</button>
-        <p style="margin-top: 1.5em;">Delete all test players (names starting with <code>___test</code>) and their statistics.</p>
-        <button type="button" id="delete-test-btn" style="background-color: #ffc107; color: black; border: none;">Delete Test Players</button>
-        <p style="margin-top: 1.5em;">Delete statistics for a specific player by name.</p>
-        <div style="display: flex; gap: 0.5em; align-items: center;">
-            <input type="text" id="player-name-input" placeholder="Enter player name..." style="flex-grow: 1; padding: 0.5em; font-size: 1em;">
-            <button type="button" id="delete-player-btn" style="background-color: #fd7e14; color: white; border: none;">Delete Player Stats</button>
-        </div>
-    </div>
 
     <script>
         const statusMessageEl = document.getElementById('status-message');
@@ -72,10 +62,6 @@
         const stopBtn = document.getElementById('stop-btn');
         const tokenInput = document.getElementById('token-input');
         const pasteBtn = document.getElementById('paste-btn');
-        const clearStatsBtn = document.getElementById('clear-stats-btn');
-        const deleteTestBtn = document.getElementById('delete-test-btn');
-        const deletePlayerBtn = document.getElementById('delete-player-btn');
-        const playerNameInput = document.getElementById('player-name-input');
 
         const API_BASE_URL = ''; // Current origin
 
@@ -160,89 +146,6 @@
         });
 
         stopBtn.addEventListener('click', () => postAction('/stop'));
-
-        clearStatsBtn.addEventListener('click', async () => {
-            const firstConfirm = confirm('⚠️ WARNING: This will permanently delete ALL statistics from the database.\n\nAre you sure you want to continue?');
-            if (!firstConfirm) return;
-
-            const secondConfirm = confirm('⚠️ FINAL WARNING: This action CANNOT be undone!\n\nAll player stats, matches, and history will be PERMANENTLY deleted.\n\nDo you really want to proceed?');
-            if (!secondConfirm) return;
-
-            try {
-                const response = await fetch(`${API_BASE_URL}/clear-stats`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' }
-                });
-
-                if (!response.ok) {
-                    const responseData = await response.json();
-                    throw new Error(responseData.message || 'Failed to clear statistics');
-                }
-
-                const responseData = await response.json();
-                alert('✅ ' + responseData.message);
-            } catch (error) {
-                alert(`❌ Error: ${error.message}`);
-                console.error('Error clearing statistics:', error);
-            }
-        });
-
-        deleteTestBtn.addEventListener('click', async () => {
-            const confirm = window.confirm('⚠️ This will delete all test players (names starting with ___test) and their statistics.\n\nAre you sure?');
-            if (!confirm) return;
-
-            try {
-                const response = await fetch(`${API_BASE_URL}/delete-test-players`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' }
-                });
-
-                if (!response.ok) {
-                    const responseData = await response.json();
-                    throw new Error(responseData.message || 'Failed to delete test players');
-                }
-
-                const responseData = await response.json();
-                alert('✅ ' + responseData.message);
-            } catch (error) {
-                alert(`❌ Error: ${error.message}`);
-                console.error('Error deleting test players:', error);
-            }
-        });
-
-        deletePlayerBtn.addEventListener('click', async () => {
-            const playerName = playerNameInput.value.trim();
-            if (!playerName) {
-                alert('⚠️ Please enter a player name.');
-                return;
-            }
-
-            const firstConfirm = confirm(`⚠️ This will permanently delete all statistics for player "${playerName}" and remove them from all matches.\n\nAre you sure you want to continue?`);
-            if (!firstConfirm) return;
-
-            const secondConfirm = confirm(`⚠️ FINAL WARNING: This action CANNOT be undone!\n\nAll stats for "${playerName}" will be PERMANENTLY deleted.\n\nDo you really want to proceed?`);
-            if (!secondConfirm) return;
-
-            try {
-                const response = await fetch(`${API_BASE_URL}/delete-player-stats`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ playerName })
-                });
-
-                if (!response.ok) {
-                    const responseData = await response.json();
-                    throw new Error(responseData.message || 'Failed to delete player stats');
-                }
-
-                const responseData = await response.json();
-                alert('✅ ' + responseData.message);
-                playerNameInput.value = ''; // Clear input after successful deletion
-            } catch (error) {
-                alert(`❌ Error: ${error.message}`);
-                console.error('Error deleting player stats:', error);
-            }
-        });
 
         // Initialize SSE connection
         const eventSource = new EventSource('/events');

--- a/danger-zone.html
+++ b/danger-zone.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Haxball Danger Zone</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; padding: 1em; max-width: 900px; margin: 0 auto; }
+        h1, h2, h3 { color: #333; }
+        button { font-size: 1em; padding: 0.5em 1em; margin-right: 0.5em; cursor: pointer; }
+        button:disabled { cursor: not-allowed; opacity: 0.6; }
+        a { color: #007bff; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        #status { background-color: #f4f4f4; padding: 1em; border-radius: 5px; margin-bottom: 1.5em; }
+        #danger-zone { margin-top: 2em; padding: 1em; border: 2px solid #dc3545; border-radius: 5px; background-color: #fff5f5; }
+        .warning { color: #dc3545; font-weight: bold; }
+        .nav-links { margin-bottom: 2em; padding-bottom: 1em; border-bottom: 1px solid #ddd; }
+        input { padding: 0.5em; font-size: 1em; }
+    </style>
+</head>
+<body>
+    <div class="nav-links">
+        <a href="/">← Back to Admin</a>
+    </div>
+
+    <h1>Danger Zone</h1>
+
+    <div id="status">
+        <h2>Room Status</h2>
+        <p><b id="status-message">Connecting...</b></p>
+        <p id="room-warning" class="warning" style="display: none;">⚠️ Room is currently running. Please stop the room before destructive database operations.</p>
+    </div>
+
+    <div id="danger-zone">
+        <h3 style="color: #dc3545;">Destructive Database Actions</h3>
+        <p>Permanently delete all statistics from the database. This action cannot be undone.</p>
+        <button type="button" id="clear-stats-btn" data-danger-action style="background-color: #dc3545; color: white; border: none;">Clear Database</button>
+        <p style="margin-top: 1.5em;">Delete all test players (names starting with <code>___test</code>) and their statistics.</p>
+        <button type="button" id="delete-test-btn" data-danger-action style="background-color: #ffc107; color: black; border: none;">Delete Test Players</button>
+        <p style="margin-top: 1.5em;">Delete statistics for a specific player by name.</p>
+        <div style="display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap;">
+            <input type="text" id="player-name-input" placeholder="Enter player name..." style="flex-grow: 1; min-width: 240px;">
+            <button type="button" id="delete-player-btn" data-danger-action style="background-color: #fd7e14; color: white; border: none;">Delete Player Stats</button>
+        </div>
+    </div>
+
+    <script>
+        const statusMessageEl = document.getElementById('status-message');
+        const roomWarningEl = document.getElementById('room-warning');
+        const clearStatsBtn = document.getElementById('clear-stats-btn');
+        const deleteTestBtn = document.getElementById('delete-test-btn');
+        const deletePlayerBtn = document.getElementById('delete-player-btn');
+        const playerNameInput = document.getElementById('player-name-input');
+        const API_BASE_URL = '';
+        let roomStatus = 'stopped';
+
+        function updateUI(state) {
+            roomStatus = state.status;
+            statusMessageEl.textContent = state.status_message || 'N/A';
+            statusMessageEl.style.color = state.status === 'running' ? 'green' : (state.status === 'stopped' ? 'red' : 'orange');
+            roomWarningEl.style.display = state.status === 'stopped' ? 'none' : 'block';
+            document.querySelectorAll('[data-danger-action]').forEach(btn => {
+                btn.disabled = state.status !== 'stopped';
+            });
+        }
+
+        function requireStoppedRoom() {
+            if (roomStatus !== 'stopped') {
+                alert('⚠️ Room must be stopped before destructive database operations. Please stop the room first.');
+                return false;
+            }
+            return true;
+        }
+
+        clearStatsBtn.addEventListener('click', async () => {
+            if (!requireStoppedRoom()) return;
+            const firstConfirm = confirm('⚠️ WARNING: This will permanently delete ALL statistics from the database.\n\nAre you sure you want to continue?');
+            if (!firstConfirm) return;
+
+            const secondConfirm = confirm('⚠️ FINAL WARNING: This action CANNOT be undone!\n\nAll player stats, matches, and history will be PERMANENTLY deleted.\n\nDo you really want to proceed?');
+            if (!secondConfirm) return;
+
+            try {
+                const response = await fetch(`${API_BASE_URL}/clear-stats`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (!response.ok) {
+                    const responseData = await response.json();
+                    throw new Error(responseData.message || 'Failed to clear statistics');
+                }
+
+                const responseData = await response.json();
+                alert('✅ ' + responseData.message);
+            } catch (error) {
+                alert(`❌ Error: ${error.message}`);
+                console.error('Error clearing statistics:', error);
+            }
+        });
+
+        deleteTestBtn.addEventListener('click', async () => {
+            if (!requireStoppedRoom()) return;
+            const confirmDelete = window.confirm('⚠️ This will delete all test players (names starting with ___test) and their statistics.\n\nAre you sure?');
+            if (!confirmDelete) return;
+
+            try {
+                const response = await fetch(`${API_BASE_URL}/delete-test-players`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (!response.ok) {
+                    const responseData = await response.json();
+                    throw new Error(responseData.message || 'Failed to delete test players');
+                }
+
+                const responseData = await response.json();
+                alert('✅ ' + responseData.message);
+            } catch (error) {
+                alert(`❌ Error: ${error.message}`);
+                console.error('Error deleting test players:', error);
+            }
+        });
+
+        deletePlayerBtn.addEventListener('click', async () => {
+            if (!requireStoppedRoom()) return;
+            const playerName = playerNameInput.value.trim();
+            if (!playerName) {
+                alert('⚠️ Please enter a player name.');
+                return;
+            }
+
+            const firstConfirm = confirm(`⚠️ This will permanently delete all statistics for player "${playerName}" and remove them from all matches.\n\nAre you sure you want to continue?`);
+            if (!firstConfirm) return;
+
+            const secondConfirm = confirm(`⚠️ FINAL WARNING: This action CANNOT be undone!\n\nAll stats for "${playerName}" will be PERMANENTLY deleted.\n\nDo you really want to proceed?`);
+            if (!secondConfirm) return;
+
+            try {
+                const response = await fetch(`${API_BASE_URL}/delete-player-stats`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ playerName })
+                });
+
+                if (!response.ok) {
+                    const responseData = await response.json();
+                    throw new Error(responseData.message || 'Failed to delete player stats');
+                }
+
+                const responseData = await response.json();
+                alert('✅ ' + responseData.message);
+                playerNameInput.value = '';
+            } catch (error) {
+                alert(`❌ Error: ${error.message}`);
+                console.error('Error deleting player stats:', error);
+            }
+        });
+
+        const eventSource = new EventSource('/events');
+        eventSource.onmessage = (event) => updateUI(JSON.parse(event.data));
+        eventSource.onerror = (err) => {
+            console.error('EventSource failed:', err);
+            statusMessageEl.textContent = 'Connection to server lost. Please refresh the page.';
+            statusMessageEl.style.color = 'red';
+            document.querySelectorAll('[data-danger-action]').forEach(btn => { btn.disabled = true; });
+        };
+    </script>
+</body>
+</html>

--- a/merge-players.html
+++ b/merge-players.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Haxball Merge Players</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; padding: 1em; max-width: 900px; margin: 0 auto; }
+        h1, h2, h3 { color: #333; }
+        button { font-size: 1em; padding: 0.5em 1em; cursor: pointer; }
+        button:disabled { cursor: not-allowed; opacity: 0.6; }
+        a { color: #007bff; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        input, select { box-sizing: border-box; padding: 0.5em; font-size: 1em; width: 100%; }
+        label { font-weight: bold; display: block; margin-bottom: 0.35em; }
+        #status { background-color: #f4f4f4; padding: 1em; border-radius: 5px; margin-bottom: 1.5em; }
+        #merge-form { border: 1px solid #ddd; border-radius: 5px; padding: 1em; background-color: #f9f9f9; }
+        .field { margin-bottom: 1em; }
+        .warning { color: #dc3545; font-weight: bold; }
+        .success { color: #28a745; font-weight: bold; }
+        .nav-links { margin-bottom: 2em; padding-bottom: 1em; border-bottom: 1px solid #ddd; }
+        #result { margin-top: 1.5em; padding: 1em; border-radius: 5px; display: none; }
+        #result.success-box { display: block; background-color: #f0fff4; border: 1px solid #28a745; }
+        #result.error-box { display: block; background-color: #fff5f5; border: 1px solid #dc3545; }
+        code { background: #eee; padding: 0.1em 0.3em; border-radius: 3px; }
+    </style>
+</head>
+<body>
+    <div class="nav-links">
+        <a href="/">← Back to Admin</a>
+    </div>
+
+    <h1>Merge Players</h1>
+
+    <div id="status">
+        <h2>Room Status</h2>
+        <p><b id="status-message">Connecting...</b></p>
+        <p id="room-warning" class="warning" style="display: none;">⚠️ Room is currently running. Please stop the room before merging players.</p>
+    </div>
+
+    <div id="merge-form">
+        <h2>Merge by Auth</h2>
+        <p>Select the duplicate/source player and the target player. The source player will be deleted after its stats and match history are merged into the target player.</p>
+
+        <div class="field">
+            <label for="source-auth">Source player auth (will be removed)</label>
+            <select id="source-auth"></select>
+        </div>
+
+        <div class="field">
+            <label for="target-auth">Target player auth (will remain)</label>
+            <select id="target-auth"></select>
+        </div>
+
+        <div class="field">
+            <label for="confirm-input">Type <code>MERGE</code> to enable the merge button</label>
+            <input type="text" id="confirm-input" placeholder="MERGE">
+        </div>
+
+        <button type="button" id="merge-btn" disabled>🔀 Merge Players</button>
+        <button type="button" id="refresh-btn">Refresh Players</button>
+    </div>
+
+    <div id="result"></div>
+
+    <script>
+        const statusMessageEl = document.getElementById('status-message');
+        const roomWarningEl = document.getElementById('room-warning');
+        const sourceAuthEl = document.getElementById('source-auth');
+        const targetAuthEl = document.getElementById('target-auth');
+        const confirmInputEl = document.getElementById('confirm-input');
+        const mergeBtn = document.getElementById('merge-btn');
+        const refreshBtn = document.getElementById('refresh-btn');
+        const resultEl = document.getElementById('result');
+        const API_BASE_URL = '';
+        let roomStatus = 'stopped';
+        let players = [];
+
+        function escapeHtml(value) {
+            return String(value).replace(/[&<>"']/g, char => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[char]));
+        }
+
+        function formatPlayer(player) {
+            return `${player.name} | auth: ${player.auth} | games: ${player.games} | goals: ${player.goals} | last seen: ${player.last_seen || 'N/A'}`;
+        }
+
+        function updateMergeButton() {
+            mergeBtn.disabled = roomStatus !== 'stopped'
+                || confirmInputEl.value.trim() !== 'MERGE'
+                || !sourceAuthEl.value
+                || !targetAuthEl.value
+                || sourceAuthEl.value === targetAuthEl.value;
+        }
+
+        function updateUI(state) {
+            roomStatus = state.status;
+            statusMessageEl.textContent = state.status_message || 'N/A';
+            statusMessageEl.style.color = state.status === 'running' ? 'green' : (state.status === 'stopped' ? 'red' : 'orange');
+            roomWarningEl.style.display = state.status === 'stopped' ? 'none' : 'block';
+            updateMergeButton();
+        }
+
+        function showResult(html, isError = false) {
+            resultEl.className = isError ? 'error-box' : 'success-box';
+            resultEl.innerHTML = html;
+        }
+
+        async function loadPlayers() {
+            try {
+                refreshBtn.disabled = true;
+                refreshBtn.textContent = 'Loading...';
+                const response = await fetch(`${API_BASE_URL}/players`);
+                if (!response.ok) {
+                    const data = await response.json();
+                    throw new Error(data.message || 'Failed to load players');
+                }
+
+                players = await response.json();
+                sourceAuthEl.replaceChildren(new Option('Select player...', ''));
+                targetAuthEl.replaceChildren(new Option('Select player...', ''));
+                for (const player of players) {
+                    sourceAuthEl.add(new Option(formatPlayer(player), player.auth));
+                    targetAuthEl.add(new Option(formatPlayer(player), player.auth));
+                }
+                updateMergeButton();
+            } catch (error) {
+                showResult(`❌ Error loading players: ${error.message}`, true);
+                console.error('Error loading players:', error);
+            } finally {
+                refreshBtn.disabled = false;
+                refreshBtn.textContent = 'Refresh Players';
+            }
+        }
+
+        mergeBtn.addEventListener('click', async () => {
+            const sourceAuth = sourceAuthEl.value;
+            const targetAuth = targetAuthEl.value;
+            if (roomStatus !== 'stopped') {
+                alert('⚠️ Room must be stopped before merging players. Please stop the room first.');
+                return;
+            }
+            if (!sourceAuth || !targetAuth || sourceAuth === targetAuth) {
+                alert('⚠️ Select two different players.');
+                return;
+            }
+            if (confirmInputEl.value.trim() !== 'MERGE') {
+                alert('⚠️ Type MERGE to confirm.');
+                return;
+            }
+
+            const source = players.find(player => player.auth === sourceAuth);
+            const target = players.find(player => player.auth === targetAuth);
+            const firstConfirm = confirm(`⚠️ Merge source player into target player?\n\nSource: ${source ? formatPlayer(source) : sourceAuth}\n\nTarget: ${target ? formatPlayer(target) : targetAuth}\n\nThe source player will be deleted.`);
+            if (!firstConfirm) return;
+            const secondConfirm = confirm('⚠️ FINAL WARNING: This action changes player statistics and match history. A backup will be created first. Continue?');
+            if (!secondConfirm) return;
+
+            try {
+                mergeBtn.disabled = true;
+                mergeBtn.textContent = 'Merging...';
+                const response = await fetch(`${API_BASE_URL}/merge-players`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ sourceAuth, targetAuth })
+                });
+                const data = await response.json();
+                if (!response.ok) {
+                    throw new Error(data.message || 'Failed to merge players');
+                }
+
+                showResult(`
+                    <h3>✅ Players merged successfully</h3>
+                    <p><b>Source:</b> ${escapeHtml(data.source.name)} (<code>${escapeHtml(data.source.auth)}</code>)</p>
+                    <p><b>Target:</b> ${escapeHtml(data.target.name)} (<code>${escapeHtml(data.target.auth)}</code>)</p>
+                    <p><b>Moved match rows:</b> ${data.movedMatchRows}</p>
+                    <p><b>Merged same-match conflicts:</b> ${data.mergedMatchConflicts}</p>
+                    <p><b>Final target stats:</b> ${data.finalStats.games} games, ${data.finalStats.goals} goals, ${data.finalStats.assists} assists</p>
+                `);
+                confirmInputEl.value = '';
+                await loadPlayers();
+            } catch (error) {
+                showResult(`❌ Error merging players: ${error.message}`, true);
+                console.error('Error merging players:', error);
+            } finally {
+                mergeBtn.textContent = '🔀 Merge Players';
+                updateMergeButton();
+            }
+        });
+
+        refreshBtn.addEventListener('click', loadPlayers);
+        sourceAuthEl.addEventListener('change', updateMergeButton);
+        targetAuthEl.addEventListener('change', updateMergeButton);
+        confirmInputEl.addEventListener('input', updateMergeButton);
+
+        loadPlayers();
+
+        const eventSource = new EventSource('/events');
+        eventSource.onmessage = (event) => updateUI(JSON.parse(event.data));
+        eventSource.onerror = (err) => {
+            console.error('EventSource failed:', err);
+            statusMessageEl.textContent = 'Connection to server lost. Please refresh the page.';
+            statusMessageEl.style.color = 'red';
+            mergeBtn.disabled = true;
+        };
+    </script>
+</body>
+</html>

--- a/server.mjs
+++ b/server.mjs
@@ -14,9 +14,23 @@ let backupDb = null;
 async function getBackupDatabase() {
     if (!backupDb) {
         backupDb = new StatsDatabase('./data/stats.db');
-        await backupDb.connect();
+        backupDb.initialize();
     }
     return backupDb;
+}
+
+function sendJson(res, statusCode, data) {
+    res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+}
+
+function ensureRoomStopped(res, action) {
+    const { status } = getRoomState();
+    if (status !== 'stopped') {
+        sendJson(res, 400, { message: `Cannot ${action} while room is ${status}. Please stop the room first.` });
+        return false;
+    }
+    return true;
 }
 
 // Function to send the current state to all connected clients
@@ -98,6 +112,26 @@ const server = http.createServer(async (req, res) => {
                 res.end(data);
             }
         });
+    } else if (pathname === '/merge-players') {
+        fs.readFile('merge-players.html', (err, data) => {
+            if (err) {
+                res.writeHead(500);
+                res.end('Error loading merge-players.html');
+            } else {
+                res.writeHead(200, { 'Content-Type': 'text/html' });
+                res.end(data);
+            }
+        });
+    } else if (pathname === '/danger-zone') {
+        fs.readFile('danger-zone.html', (err, data) => {
+            if (err) {
+                res.writeHead(500);
+                res.end('Error loading danger-zone.html');
+            } else {
+                res.writeHead(200, { 'Content-Type': 'text/html' });
+                res.end(data);
+            }
+        });
     } else if (pathname === '/events') {
         // SSE endpoint
         res.writeHead(200, {
@@ -144,13 +178,10 @@ const server = http.createServer(async (req, res) => {
     } else if (pathname === '/clear-stats' && req.method === 'POST') {
         (async () => {
             try {
+                if (!ensureRoomStopped(res, 'clear statistics')) return;
                 const statsTracker = getStatsTracker();
-                if (!statsTracker) {
-                    res.writeHead(400, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ message: "Stats tracker not initialized. Start the room first." }));
-                    return;
-                }
-                await statsTracker.clearStats();
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                await db.clearStats();
                 res.writeHead(200, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ message: "Statistics cleared successfully." }));
             } catch (error) {
@@ -161,13 +192,10 @@ const server = http.createServer(async (req, res) => {
     } else if (pathname === '/delete-test-players' && req.method === 'POST') {
         (async () => {
             try {
+                if (!ensureRoomStopped(res, 'delete test players')) return;
                 const statsTracker = getStatsTracker();
-                if (!statsTracker) {
-                    res.writeHead(400, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ message: "Stats tracker not initialized. Start the room first." }));
-                    return;
-                }
-                const deletedCount = await statsTracker.deleteTestPlayers();
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                const deletedCount = await db.deleteTestPlayers();
                 res.writeHead(200, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ message: `Deleted ${deletedCount} test player(s) and their statistics.` }));
             } catch (error) {
@@ -180,6 +208,7 @@ const server = http.createServer(async (req, res) => {
         req.on('data', chunk => { body += chunk.toString(); });
         req.on('end', async () => {
             try {
+                if (!ensureRoomStopped(res, 'delete player stats')) return;
                 const { playerName } = JSON.parse(body);
                 if (!playerName) {
                     res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -187,12 +216,8 @@ const server = http.createServer(async (req, res) => {
                     return;
                 }
                 const statsTracker = getStatsTracker();
-                if (!statsTracker) {
-                    res.writeHead(400, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ message: "Stats tracker not initialized. Start the room first." }));
-                    return;
-                }
-                const result = await statsTracker.deletePlayerStats(playerName);
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                const result = await db.deletePlayerStats(playerName);
                 if (result === null) {
                     res.writeHead(404, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({ message: `Player "${playerName}" not found.` }));
@@ -203,6 +228,44 @@ const server = http.createServer(async (req, res) => {
             } catch (error) {
                 res.writeHead(500, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ message: `Failed to delete player stats: ${error.message}` }));
+            }
+        });
+    } else if (pathname === '/players' && req.method === 'GET') {
+        (async () => {
+            try {
+                const statsTracker = getStatsTracker();
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                const players = db.getAllPlayers();
+                sendJson(res, 200, players);
+            } catch (error) {
+                sendJson(res, 500, { message: `Failed to list players: ${error.message}` });
+            }
+        })();
+    } else if (pathname === '/merge-players' && req.method === 'POST') {
+        let body = '';
+        req.on('data', chunk => { body += chunk.toString(); });
+        req.on('end', async () => {
+            try {
+                if (!ensureRoomStopped(res, 'merge players')) return;
+                const { sourceAuth, targetAuth } = JSON.parse(body);
+                if (!sourceAuth || !targetAuth) {
+                    sendJson(res, 400, { message: "Source auth and target auth are required." });
+                    return;
+                }
+                if (sourceAuth === targetAuth) {
+                    sendJson(res, 400, { message: "Source auth and target auth must be different." });
+                    return;
+                }
+
+                const statsTracker = getStatsTracker();
+                const db = statsTracker?.db ?? await getBackupDatabase();
+                const result = await db.mergePlayers(sourceAuth, targetAuth);
+                sendJson(res, 200, {
+                    message: `Merged player "${result.source.name}" into "${result.target.name}".`,
+                    ...result
+                });
+            } catch (error) {
+                sendJson(res, 500, { message: `Failed to merge players: ${error.message}` });
             }
         });
     } else if (pathname === '/list-backups' && req.method === 'GET') {
@@ -223,12 +286,7 @@ const server = http.createServer(async (req, res) => {
         req.on('data', chunk => { body += chunk.toString(); });
         req.on('end', async () => {
             try {
-                const { status } = getRoomState();
-                if (status !== 'stopped') {
-                    res.writeHead(400, { 'Content-Type': 'application/json' });
-                    res.end(JSON.stringify({ message: `Cannot restore backup while room is ${status}. Please stop the room first.` }));
-                    return;
-                }
+                if (!ensureRoomStopped(res, 'restore backup')) return;
 
                 const { filename } = JSON.parse(body);
                 if (!filename) {

--- a/stats/database.mjs
+++ b/stats/database.mjs
@@ -233,6 +233,18 @@ export class StatsDatabase {
     }
 
     /**
+     * Get all players for admin tools
+     */
+    getAllPlayers() {
+        const stmt = this.db.prepare(`
+            SELECT *
+            FROM players
+            ORDER BY LOWER(name), last_seen DESC
+        `);
+        return stmt.all();
+    }
+
+    /**
      * Save match to database
      */
     saveMatch(matchData) {
@@ -400,6 +412,122 @@ export class StatsDatabase {
         });
 
         return deleteTransaction();
+    }
+
+    /**
+     * Merge one player into another by auth
+     * Source player is removed after stats and match history are merged into target
+     */
+    async mergePlayers(sourceAuth, targetAuth) {
+        if (!sourceAuth || !targetAuth) {
+            throw new Error('Source auth and target auth are required');
+        }
+
+        if (sourceAuth === targetAuth) {
+            throw new Error('Source auth and target auth must be different');
+        }
+
+        // Create backup first - if it fails, merge will not proceed
+        const backupPath = await this.createBackup();
+        console.log('[DB] Backup successful, proceeding with player merge');
+
+        const mergeTransaction = this.db.transaction(() => {
+            const source = this.getPlayer(sourceAuth);
+            const target = this.getPlayer(targetAuth);
+
+            if (!source) {
+                throw new Error(`Source player not found: ${sourceAuth}`);
+            }
+
+            if (!target) {
+                throw new Error(`Target player not found: ${targetAuth}`);
+            }
+
+            const conflictRows = this.db.prepare(`
+                SELECT source_mp.match_id, source_mp.goals, source_mp.assists
+                FROM match_players source_mp
+                INNER JOIN match_players target_mp
+                    ON target_mp.match_id = source_mp.match_id
+                    AND target_mp.player_auth = ?
+                WHERE source_mp.player_auth = ?
+            `).all(targetAuth, sourceAuth);
+
+            const mergedMatchConflicts = conflictRows.length;
+
+            const mergeMatchStats = this.db.prepare(`
+                UPDATE match_players
+                SET goals = goals + ?, assists = assists + ?
+                WHERE match_id = ? AND player_auth = ?
+            `);
+
+            const deleteSourceMatchRow = this.db.prepare(`
+                DELETE FROM match_players
+                WHERE match_id = ? AND player_auth = ?
+            `);
+
+            for (const row of conflictRows) {
+                mergeMatchStats.run(row.goals, row.assists, row.match_id, targetAuth);
+                deleteSourceMatchRow.run(row.match_id, sourceAuth);
+            }
+
+            const moveResult = this.db.prepare(`
+                UPDATE match_players
+                SET player_auth = ?
+                WHERE player_auth = ?
+            `).run(targetAuth, sourceAuth);
+
+            this.db.prepare(`
+                UPDATE players
+                SET
+                    goals = goals + ?,
+                    assists = assists + ?,
+                    own_goals = own_goals + ?,
+                    games = games + ?,
+                    wins = wins + ?,
+                    losses = losses + ?,
+                    draws = draws + ?,
+                    clean_sheets = clean_sheets + ?,
+                    minutes_played = minutes_played + ?,
+                    best_streak = MAX(best_streak, ?),
+                    last_seen = MAX(last_seen, ?)
+                WHERE auth = ?
+            `).run(
+                source.goals,
+                source.assists,
+                source.own_goals,
+                source.games,
+                source.wins,
+                source.losses,
+                source.draws,
+                source.clean_sheets,
+                source.minutes_played,
+                source.best_streak,
+                source.last_seen,
+                targetAuth
+            );
+
+            this.db.prepare('DELETE FROM players WHERE auth = ?').run(sourceAuth);
+
+            const finalStats = this.getPlayer(targetAuth);
+
+            console.log(`[DB] Merged player "${source.name}" (${sourceAuth}) into "${target.name}" (${targetAuth})`);
+
+            return {
+                source: {
+                    auth: source.auth,
+                    name: source.name
+                },
+                target: {
+                    auth: target.auth,
+                    name: target.name
+                },
+                movedMatchRows: moveResult.changes,
+                mergedMatchConflicts,
+                finalStats
+            };
+        });
+
+        return mergeTransaction();
     }
 
     /**

--- a/stats/tracker.mjs
+++ b/stats/tracker.mjs
@@ -407,6 +407,20 @@ export class HaxballStatsTracker {
     }
 
     /**
+     * Get all players for admin tools
+     */
+    getAllPlayers() {
+        return this.db.getAllPlayers();
+    }
+
+    /**
+     * Merge one player into another by auth
+     */
+    async mergePlayers(sourceAuth, targetAuth) {
+        return await this.db.mergePlayers(sourceAuth, targetAuth);
+    }
+
+    /**
      * Close database connection
      */
     close() {


### PR DESCRIPTION
### Motivation

- Provide dedicated admin interfaces for destructive DB operations and player merging instead of embedding them in the main admin page.
- Prevent unsafe operations while the room is running by enforcing room state checks on the server and client.
- Expose programmatic APIs to list players and merge player records to support the new UIs.

### Description

- Split the previous inline danger-zone controls out of `admin.html` into a new `danger-zone.html` page and added a new `merge-players.html` page, updating `admin.html` navigation links accordingly.
- Added server helpers `sendJson` and `ensureRoomStopped` to `server.mjs`, wired new routes for `GET /players`, `POST /merge-players`, and served the new HTML pages, and centralized checks so destructive actions require the room to be `stopped` (uses `ensureRoomStopped`).
- Updated backup DB initialization in `getBackupDatabase` to use `initialize()` and changed destructive endpoints to operate on the currently active DB via `getStatsTracker()` or fall back to the backup DB when the tracker is not available.
- Implemented `getAllPlayers` and `mergePlayers` on the SQLite-backed `StatsDatabase` in `stats/database.mjs` to list players and atomically merge one player into another (creates a backup first, consolidates match rows and stats, removes source player), and added corresponding proxy methods in `stats/tracker.mjs`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f7683b0788333ac08f70a8d82abe3)