### PR TITLE
Update hax-server image references to hax-server/app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,4 +16,4 @@ jobs:
           method: "POST"
           username: ${{ secrets.WEBHOOK_USERNAME }}
           password: ${{ secrets.WEBHOOK_PASSWORD }}
-          data: '[{ "Name": "hax-server", "Version": "0.1.0" }]'
+          data: '[{ "Name": "hax-server/app", "Version": "0.1.0" }]'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8" # Specifying a version is good practice
 
 services:
   haxball-server:
-    image: "register.kacpersledz.com/hax-server:0.1.0"
+    image: "register.kacpersledz.com/hax-server/app:0.1.0"
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
### Motivation
- Ensure deployment webhook payload and Docker Compose use the correct image path by adding the `/app` segment to the `hax-server` image name.

### Description
- Updated the webhook `data` in `.github/workflows/deploy.yml` from `[{ "Name": "hax-server", "Version": "0.1.0" }]` to `[{ "Name": "hax-server/app", "Version": "0.1.0" }]` and changed the `image` in `docker-compose.yml` from `"register.kacpersledz.com/hax-server:0.1.0"` to `"register.kacpersledz.com/hax-server/app:0.1.0"`.

### Testing
- Ran `git diff --check` and `git status --short`, both completed with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f85019214833382963e33b81d9a80)