### PR TITLE
Fix merge-players POST route, switch to WHATWG URL, and improve UI JSON error handling

### DIFF
--- a/merge-players.html
+++ b/merge-players.html
@@ -111,17 +111,30 @@
             resultEl.innerHTML = html;
         }
 
+        async function readJsonResponse(response) {
+            const contentType = response.headers.get('content-type') || '';
+            const body = await response.text();
+            if (!contentType.includes('application/json')) {
+                throw new Error(`Expected JSON response, got ${contentType || 'unknown content type'} with status ${response.status}.`);
+            }
+            try {
+                return JSON.parse(body);
+            } catch (error) {
+                throw new Error(`Invalid JSON response from server: ${error.message}`);
+            }
+        }
+
         async function loadPlayers() {
             try {
                 refreshBtn.disabled = true;
                 refreshBtn.textContent = 'Loading...';
                 const response = await fetch(`${API_BASE_URL}/players`);
+                const data = await readJsonResponse(response);
                 if (!response.ok) {
-                    const data = await response.json();
                     throw new Error(data.message || 'Failed to load players');
                 }
 
-                players = await response.json();
+                players = data;
                 sourceAuthEl.replaceChildren(new Option('Select player...', ''));
                 targetAuthEl.replaceChildren(new Option('Select player...', ''));
                 for (const player of players) {
@@ -169,7 +182,7 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ sourceAuth, targetAuth })
                 });
-                const data = await response.json();
+                const data = await readJsonResponse(response);
                 if (!response.ok) {
                     throw new Error(data.message || 'Failed to merge players');
                 }

--- a/server.mjs
+++ b/server.mjs
@@ -1,6 +1,5 @@
 import http from 'http';
 import fs from 'fs';
-import url from 'url';
 import path from 'path';
 import { start, stop, getRoomState, setStateUpdateCallback, getStatsTracker } from './haxball.mjs';
 import { StatsDatabase } from './stats/index.mjs';
@@ -44,7 +43,7 @@ function sendStateToAllClients() {
 setStateUpdateCallback(sendStateToAllClients);
 
 const server = http.createServer(async (req, res) => {
-    const parsedUrl = url.parse(req.url, true);
+    const parsedUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
     const pathname = parsedUrl.pathname;
 
     // Unprotected route for joining the room
@@ -112,7 +111,7 @@ const server = http.createServer(async (req, res) => {
                 res.end(data);
             }
         });
-    } else if (pathname === '/merge-players') {
+    } else if (pathname === '/merge-players' && req.method === 'GET') {
         fs.readFile('merge-players.html', (err, data) => {
             if (err) {
                 res.writeHead(500);
@@ -308,7 +307,7 @@ const server = http.createServer(async (req, res) => {
     } else if (pathname === '/download-backup' && req.method === 'GET') {
         (async () => {
             try {
-                const { file } = parsedUrl.query;
+                const file = parsedUrl.searchParams.get('file');
                 if (!file) {
                     res.writeHead(400, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({ message: "Backup filename is required." }));


### PR DESCRIPTION
### Motivation
- POST requests to `/merge-players` were receiving the HTML page and causing `Unexpected token '<'` client-side JSON parse errors, so the HTML route must only serve `GET` requests. 
- The server used the deprecated `url.parse()` API which triggers a `DEP0169` warning and is error-prone, so it should use the WHATWG `URL` API. 
- The merge UI should handle non-JSON or invalid JSON responses more gracefully and surface clearer errors instead of raw parse exceptions. 

### Description
- Restrict the HTML route to `GET /merge-players` so `POST /merge-players` reaches the JSON merge endpoint instead of returning the HTML page. 
- Replace `url.parse(req.url, true)` with the WHATWG `URL` API and derive `pathname` from `parsedUrl.pathname`. 
- Update backup download parsing to use `parsedUrl.searchParams.get('file')` instead of `parsedUrl.query`. 
- Add a shared `readJsonResponse` helper to `merge-players.html` that validates `Content-Type`, reads the response text, and throws informative errors for non-JSON or invalid JSON responses; use it for both the players list and merge POST responses. 

### Testing
- Ran `node --check server.mjs` which succeeded. 
- Ran `node --check stats/database.mjs` which succeeded. 
- Attempted to start the server with `PORT=18080 node server.mjs` and perform `curl` smoke requests, but the run failed due to missing runtime dependencies (`ERR_MODULE_NOT_FOUND` for `playwright`) so the HTTP integration test could not complete. 
- Attempted `npm ci` to install dependencies but it failed with `403 Forbidden` when fetching `better-sqlite3`, preventing full end-to-end verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f887be04083338b15d10da64d3ea7)