### PR TITLE
Simplify goal attribution and reduce false own goals

### DIFF
--- a/stats/goal-attribution.mjs
+++ b/stats/goal-attribution.mjs
@@ -2,15 +2,21 @@ export function createGoalAttributionEngine(options = {}) {
     const DEFAULTS = {
         assistTimeWindowMs: 3000,
         maxGoalTouchAgeMs: 3000,
-        samePlayerTouchThrottleMs: 700,
         proximityAfterKickSuppressMs: 250,
-        maxTouches: 30,
         contactTolerance: 0.5,
         tieDistanceTolerance: 0.01,
         diagnostics: false,
     };
     const config = { ...DEFAULTS, ...options };
-    let touches = [];
+
+    // This is deliberately a pair, rather than a chronological event log. It
+    // represents the current ball owner and the player who touched it before
+    // that owner. Consecutive contacts from one player enrich currentTouch but
+    // never create a new attribution candidate. The tiny team index is only
+    // used to recover the attacker through a run of proximity deflections.
+    let currentTouch = null;
+    let previousDifferentTouch = null;
+    let latestTouchByTeam = new Map();
     let lastKickPlayerId = null;
     let lastKickTimestamp = 0;
 
@@ -21,6 +27,7 @@ export function createGoalAttributionEngine(options = {}) {
     };
 
     const samePlayer = (a, b) => a && b && a.playerId === b.playerId;
+    const isRecent = (touch, timestamp) => touch && timestamp - touch.timestamp <= config.maxGoalTouchAgeMs;
     const publicPlayer = (touch) => touch ? ({
         id: touch.playerId,
         auth: touch.playerAuth || null,
@@ -36,95 +43,140 @@ export function createGoalAttributionEngine(options = {}) {
         timestamp: touch.timestamp,
         matchTime: touch.matchTime ?? null,
         position: touch.position ? { x: touch.position.x, y: touch.position.y } : null,
-        source: touch.source || 'proximity',
+        source: touch.source === 'kick' ? 'kick' : 'proximity',
     });
 
-    function mergeLastTouch(touch) {
-        const last = touches[touches.length - 1];
-        touches[touches.length - 1] = { ...last, ...touch };
-        debug('touch-updated', touches[touches.length - 1]);
-    }
-
-    function shouldRecord(touch) {
-        const last = touches[touches.length - 1];
-        if (!last) return { action: 'append' };
-        if (!samePlayer(last, touch)) return { action: 'append' };
-
-        const elapsed = touch.timestamp - last.timestamp;
-        if (touch.source === 'proximity' && last.source === 'kick' && elapsed <= config.proximityAfterKickSuppressMs) {
-            return { action: 'ignore' };
-        }
-        if (touch.source === 'kick' && last.source === 'proximity') {
-            return { action: 'replace-last' };
-        }
-        if (elapsed >= config.samePlayerTouchThrottleMs) {
-            return { action: 'append' };
-        }
-        return { action: 'ignore' };
+    function mergeCurrentTouch(touch) {
+        // A kick is stronger evidence than proximity and must never be
+        // downgraded by a later proximity sample from the same player.
+        currentTouch = {
+            ...currentTouch,
+            ...touch,
+            source: currentTouch.source === 'kick' || touch.source === 'kick' ? 'kick' : 'proximity',
+        };
+        latestTouchByTeam.set(currentTouch.playerTeam, currentTouch);
+        debug('touch-updated', currentTouch);
     }
 
     function recordTouch(touch) {
         if (!touch || touch.playerTeam === 0 || touch.playerId == null || touch.timestamp == null) return false;
+
         const normalized = normalizeTouch(touch);
         if (normalized.source === 'kick') {
             lastKickPlayerId = normalized.playerId;
             lastKickTimestamp = normalized.timestamp;
         }
-        const decision = shouldRecord(normalized);
-        if (decision.action === 'ignore') return false;
-        if (decision.action === 'replace-last') {
-            mergeLastTouch(normalized);
+
+        if (samePlayer(currentTouch, normalized)) {
+            mergeCurrentTouch(normalized);
             return true;
         }
-        touches.push(normalized);
-        if (touches.length > config.maxTouches) touches = touches.slice(-config.maxTouches);
-        debug('touch', normalized);
+
+        previousDifferentTouch = currentTouch;
+        currentTouch = normalized;
+        latestTouchByTeam.set(currentTouch.playerTeam, currentTouch);
+        debug('touch', currentTouch, 'previous', previousDifferentTouch);
         return true;
     }
 
-    function findAssist(scorerTouch, scorerIndex, scoringTeam) {
-        let blockedByOpponent = false;
-        for (let i = scorerIndex - 1; i >= 0; i--) {
-            const touch = touches[i];
-            if (samePlayer(touch, scorerTouch)) continue;
-            if (touch.playerTeam !== scoringTeam) {
-                blockedByOpponent = true;
-                break;
-            }
-            const passToScorerTime = scorerTouch.timestamp - touch.timestamp;
-            if (passToScorerTime > config.assistTimeWindowMs) {
-                return { assister: null, reason: 'assist-expired' };
-            }
-            return { assister: publicPlayer(touch), reason: 'assist-found' };
+    function resolveAssist(scorerTouch, scoringTeam) {
+        const candidate = previousDifferentTouch;
+        if (!candidate) return { assister: null, reason: 'no-assist-candidate' };
+        if (candidate.playerTeam !== scoringTeam) return { assister: null, reason: 'assist-blocked-by-opponent' };
+        if (samePlayer(candidate, scorerTouch)) return { assister: null, reason: 'no-assist-candidate' };
+
+        if (scorerTouch.timestamp - candidate.timestamp > config.assistTimeWindowMs) {
+            return { assister: null, reason: 'assist-expired' };
         }
-        return { assister: null, reason: blockedByOpponent ? 'assist-blocked-by-opponent' : 'no-assist-candidate' };
+        return { assister: publicPlayer(candidate), reason: 'assist-found' };
+    }
+
+    function unknownGoal() {
+        return {
+            type: 'unknown',
+            scorer: null,
+            assister: null,
+            isOwnGoal: false,
+            confidence: 'low',
+            reason: 'no-recent-scoring-touch',
+            assistReason: null,
+        };
     }
 
     function resolveGoal({ scoringTeam, timestamp }) {
-        const goalTimestamp = timestamp;
-        const lastIndex = touches.length - 1;
-        const lastTouch = touches[lastIndex];
-        if (!lastTouch || goalTimestamp - lastTouch.timestamp > config.maxGoalTouchAgeMs) {
-            const result = { type: 'unknown', scorer: null, assister: null, isOwnGoal: false, confidence: 'low', reason: 'no-recent-touch', assistReason: null };
-            debug('goal', result, touches.slice(-6));
+        if (!isRecent(currentTouch, timestamp)) {
+            const result = unknownGoal();
+            debug('goal', result, getTouches());
             return result;
         }
 
-        if (lastTouch.playerTeam !== scoringTeam) {
-            const result = { type: 'own_goal', scorer: publicPlayer(lastTouch), assister: null, isOwnGoal: true, confidence: 'high', reason: 'last-touch-opponent', assistReason: null };
-            debug('goal', result, touches.slice(-6));
+        if (currentTouch.playerTeam === scoringTeam) {
+            const assist = resolveAssist(currentTouch, scoringTeam);
+            const result = {
+                type: 'goal',
+                scorer: publicPlayer(currentTouch),
+                assister: assist.assister,
+                isOwnGoal: false,
+                confidence: 'high',
+                reason: 'last-touch-scoring-team',
+                assistReason: assist.reason,
+            };
+            debug('goal', result, getTouches());
             return result;
         }
 
-        const assist = findAssist(lastTouch, lastIndex, scoringTeam);
-        const result = { type: 'goal', scorer: publicPlayer(lastTouch), assister: assist.assister, isOwnGoal: false, confidence: 'high', reason: 'last-touch-scoring-team', assistReason: assist.reason };
-        debug('goal', result, touches.slice(-6));
+        if (currentTouch.source === 'kick') {
+            const result = {
+                type: 'own_goal',
+                scorer: publicPlayer(currentTouch),
+                assister: null,
+                isOwnGoal: true,
+                confidence: 'high',
+                reason: 'opponent-kick-own-goal',
+                assistReason: null,
+            };
+            debug('goal', result, getTouches());
+            return result;
+        }
+
+        // Proximity alone is not enough evidence for an own goal. Recover the
+        // latest recent scoring-team touch, while keeping the defender contact
+        // as an assist boundary.
+        const scoringTouch = latestTouchByTeam.get(scoringTeam);
+        if (scoringTouch && isRecent(scoringTouch, timestamp)) {
+            const result = {
+                type: 'goal',
+                scorer: publicPlayer(scoringTouch),
+                assister: null,
+                isOwnGoal: false,
+                confidence: 'medium',
+                reason: 'opponent-proximity-deflection',
+                assistReason: 'assist-blocked-by-opponent',
+            };
+            debug('goal', result, getTouches());
+            return result;
+        }
+
+        const result = unknownGoal();
+        debug('goal', result, getTouches());
         return result;
     }
 
-    function resetPlay() { touches = []; lastKickPlayerId = null; lastKickTimestamp = 0; }
+    function resetPlay() {
+        currentTouch = null;
+        previousDifferentTouch = null;
+        latestTouchByTeam = new Map();
+        lastKickPlayerId = null;
+        lastKickTimestamp = 0;
+    }
+
     function resetMatch() { resetPlay(); }
-    function getTouches() { return touches.map(t => ({ ...t, position: t.position ? { ...t.position } : null })); }
+
+    function getTouches() {
+        return [previousDifferentTouch, currentTouch]
+            .filter(Boolean)
+            .map(touch => ({ ...touch, position: touch.position ? { ...touch.position } : null }));
+    }
 
     function selectClosestContact({ ballPosition, ballRadius, players, timestamp }) {
         if (!ballPosition || !Number.isFinite(ballRadius) || !Array.isArray(players)) return null;

--- a/stats/goal-attribution.mjs
+++ b/stats/goal-attribution.mjs
@@ -2,6 +2,7 @@ export function createGoalAttributionEngine(options = {}) {
     const DEFAULTS = {
         assistTimeWindowMs: 3000,
         maxGoalTouchAgeMs: 3000,
+        ownGoalKickMaxAgeMs: 750,
         proximityAfterKickSuppressMs: 250,
         contactTolerance: 0.5,
         tieDistanceTolerance: 0.01,
@@ -27,7 +28,10 @@ export function createGoalAttributionEngine(options = {}) {
     };
 
     const samePlayer = (a, b) => a && b && a.playerId === b.playerId;
-    const isRecent = (touch, timestamp) => touch && timestamp - touch.timestamp <= config.maxGoalTouchAgeMs;
+    const isRecent = (touch, timestamp) => touch && timestamp - touch.lastTouchTimestamp >= 0 &&
+        timestamp - touch.lastTouchTimestamp <= config.maxGoalTouchAgeMs;
+    const hasRecentKick = (touch, timestamp) => touch && touch.lastKickTimestamp != null &&
+        timestamp - touch.lastKickTimestamp >= 0 && timestamp - touch.lastKickTimestamp <= config.ownGoalKickMaxAgeMs;
     const publicPlayer = (touch) => touch ? ({
         id: touch.playerId,
         auth: touch.playerAuth || null,
@@ -46,12 +50,29 @@ export function createGoalAttributionEngine(options = {}) {
         source: touch.source === 'kick' ? 'kick' : 'proximity',
     });
 
+    function createLogicalTouch(touch) {
+        return {
+            ...touch,
+            // `timestamp` remains a diagnostic compatibility alias for the
+            // latest physical contact. Goal recency must use the explicit
+            // field so it cannot be confused with the kick or takeover time.
+            firstTouchTimestamp: touch.timestamp,
+            lastTouchTimestamp: touch.timestamp,
+            lastKickTimestamp: touch.source === 'kick' ? touch.timestamp : null,
+        };
+    }
+
     function mergeCurrentTouch(touch) {
         // A kick is stronger evidence than proximity and must never be
-        // downgraded by a later proximity sample from the same player.
+        // downgraded by a later proximity sample from the same player. Its
+        // time is tracked independently so that kick evidence cannot be
+        // refreshed by subsequent proximity contacts.
         currentTouch = {
             ...currentTouch,
             ...touch,
+            firstTouchTimestamp: currentTouch.firstTouchTimestamp,
+            lastTouchTimestamp: touch.timestamp,
+            lastKickTimestamp: touch.source === 'kick' ? touch.timestamp : currentTouch.lastKickTimestamp,
             source: currentTouch.source === 'kick' || touch.source === 'kick' ? 'kick' : 'proximity',
         };
         latestTouchByTeam.set(currentTouch.playerTeam, currentTouch);
@@ -73,7 +94,7 @@ export function createGoalAttributionEngine(options = {}) {
         }
 
         previousDifferentTouch = currentTouch;
-        currentTouch = normalized;
+        currentTouch = createLogicalTouch(normalized);
         latestTouchByTeam.set(currentTouch.playerTeam, currentTouch);
         debug('touch', currentTouch, 'previous', previousDifferentTouch);
         return true;
@@ -85,7 +106,7 @@ export function createGoalAttributionEngine(options = {}) {
         if (candidate.playerTeam !== scoringTeam) return { assister: null, reason: 'assist-blocked-by-opponent' };
         if (samePlayer(candidate, scorerTouch)) return { assister: null, reason: 'no-assist-candidate' };
 
-        if (scorerTouch.timestamp - candidate.timestamp > config.assistTimeWindowMs) {
+        if (scorerTouch.firstTouchTimestamp - candidate.lastTouchTimestamp > config.assistTimeWindowMs) {
             return { assister: null, reason: 'assist-expired' };
         }
         return { assister: publicPlayer(candidate), reason: 'assist-found' };
@@ -125,7 +146,7 @@ export function createGoalAttributionEngine(options = {}) {
             return result;
         }
 
-        if (currentTouch.source === 'kick') {
+        if (hasRecentKick(currentTouch, timestamp)) {
             const result = {
                 type: 'own_goal',
                 scorer: publicPlayer(currentTouch),

--- a/tests/goal-attribution.test.mjs
+++ b/tests/goal-attribution.test.mjs
@@ -9,158 +9,284 @@ const P = {
     B: { playerId: 2, playerAuth: 'auth-b', playerName: 'B', playerTeam: RED },
     D: { playerId: 4, playerAuth: 'auth-d', playerName: 'D', playerTeam: BLUE },
 };
-const touch = (p, timestamp, source = 'kick') => ({ ...p, timestamp, matchTime: timestamp / 1000, position: { x: timestamp, y: 0 }, source });
-const engine = (options = {}) => new GoalAttributionEngine({ assistTimeWindowMs: 3000, maxGoalTouchAgeMs: 3000, samePlayerTouchThrottleMs: 100, ...options });
+const touch = (player, timestamp, source = 'kick') => ({
+    ...player,
+    timestamp,
+    matchTime: timestamp / 1000,
+    position: { x: timestamp, y: 0 },
+    source,
+});
+const engine = (options = {}) => new GoalAttributionEngine({
+    assistTimeWindowMs: 3000,
+    maxGoalTouchAgeMs: 3000,
+    ...options,
+});
 
 test('direct goal without assist', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1200 });
-    assert.equal(r.type, 'goal'); assert.equal(r.scorer.name, 'A'); assert.equal(r.assister, null); assert.equal(r.isOwnGoal, false);
-});
-
-test('simple assist', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.recordTouch(touch(P.B, 1500));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1700 });
-    assert.equal(r.scorer.name, 'B'); assert.equal(r.assister.name, 'A');
-});
-
-test('dribble after pass keeps assist', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.recordTouch(touch(P.B, 1200)); e.recordTouch(touch(P.B, 1400)); e.recordTouch(touch(P.B, 1600));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1800 });
-    assert.equal(r.scorer.name, 'B'); assert.equal(r.assister.name, 'A');
-});
-
-test('no self assist', () => {
-    const e = engine(); e.recordTouch(touch(P.B, 1000)); e.recordTouch(touch(P.B, 1200));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1400 });
-    assert.equal(r.scorer.name, 'B'); assert.equal(r.assister, null);
-});
-
-test('own goal after opponent shot', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.recordTouch(touch(P.D, 1300));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1500 });
-    assert.equal(r.type, 'own_goal'); assert.equal(r.scorer.name, 'D'); assert.equal(r.assister, null); assert.equal(r.isOwnGoal, true);
-});
-
-test('defender touch blocks assist', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.recordTouch(touch(P.D, 1200)); e.recordTouch(touch(P.B, 1400));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1600 });
-    assert.equal(r.scorer.name, 'B'); assert.equal(r.assister, null); assert.equal(r.assistReason, 'assist-blocked-by-opponent');
-});
-
-test('assist after many scorer touches', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.recordTouch(touch(P.B, 1200)); e.recordTouch(touch(P.B, 1350)); e.recordTouch(touch(P.B, 1500));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1700 });
-    assert.equal(r.scorer.name, 'B'); assert.equal(r.assister.name, 'A');
-});
-
-test('expired assist window', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.recordTouch(touch(P.B, 5000));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 5200 });
-    assert.equal(r.scorer.name, 'B'); assert.equal(r.assister, null); assert.equal(r.assistReason, 'assist-expired');
-});
-
-test('stale last touch makes unknown scorer', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 5000 });
-    assert.equal(r.type, 'unknown'); assert.equal(r.scorer, null);
-});
-
-test('post bounce does not change scorer', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1800 });
-    assert.equal(r.scorer.name, 'A');
-});
-
-test('proximity contact can decide goal', () => {
-    const e = engine(); e.recordTouch(touch(P.D, 1000, 'proximity'));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1200 });
-    assert.equal(r.type, 'own_goal'); assert.equal(r.scorer.name, 'D');
-});
-
-test('deduplicates kick followed by proximity for same player', () => {
     const e = engine();
-    assert.equal(e.recordTouch(touch(P.A, 1000, 'kick')), true);
-    assert.equal(e.recordTouch(touch(P.A, 1050, 'proximity')), false);
-    const history = e.getTouches();
-    assert.equal(history.length, 1);
-    assert.equal(history[0].source, 'kick');
-    assert.equal(history[0].timestamp, 1000);
+    e.recordTouch(touch(P.A, 1000));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1200 });
+
+    assert.equal(result.type, 'goal');
+    assert.equal(result.scorer.name, 'A');
+    assert.equal(result.assister, null);
+    assert.equal(result.isOwnGoal, false);
+    assert.equal(result.reason, 'last-touch-scoring-team');
 });
 
-test('selects closest simultaneous contact deterministically', () => {
+test('simple assist uses the previous different scoring-team player', () => {
     const e = engine();
-    const input = { ballPosition: { x: 0, y: 0 }, ballRadius: 10, timestamp: 1000, players: [
-        { id: 2, team: RED, disc: { x: 12, y: 0 }, playerRadius: 5 },
-        { id: 1, team: RED, disc: { x: 11, y: 0 }, playerRadius: 5 },
-    ]};
+    e.recordTouch(touch(P.A, 1000));
+    e.recordTouch(touch(P.B, 1500));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1700 });
+
+    assert.equal(result.scorer.name, 'B');
+    assert.equal(result.assister.name, 'A');
+    assert.equal(result.assistReason, 'assist-found');
+});
+
+test('repeated scorer touches do not destroy an assist', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    e.recordTouch(touch(P.B, 1200));
+    e.recordTouch(touch(P.B, 1400, 'proximity'));
+    e.recordTouch(touch(P.B, 1600));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1800 });
+
+    assert.equal(result.scorer.name, 'B');
+    assert.equal(result.assister.name, 'A');
+    assert.equal(e.getTouches().length, 2);
+});
+
+test('does not award a self-assist', () => {
+    const e = engine();
+    e.recordTouch(touch(P.B, 1000));
+    e.recordTouch(touch(P.B, 1200));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1400 });
+
+    assert.equal(result.scorer.name, 'B');
+    assert.equal(result.assister, null);
+});
+
+test('attacker kick then defender proximity is the attacker goal, not an own goal', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000, 'kick'));
+    e.recordTouch(touch(P.D, 1200, 'proximity'));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1400 });
+
+    assert.equal(result.type, 'goal');
+    assert.equal(result.scorer.name, 'A');
+    assert.equal(result.assister, null);
+    assert.equal(result.isOwnGoal, false);
+    assert.equal(result.reason, 'opponent-proximity-deflection');
+    assert.equal(result.assistReason, 'assist-blocked-by-opponent');
+});
+
+test('latest attacker before a defender proximity scores without an assist across the deflection', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    e.recordTouch(touch(P.B, 1200));
+    e.recordTouch(touch(P.D, 1400, 'proximity'));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1600 });
+
+    assert.equal(result.type, 'goal');
+    assert.equal(result.scorer.name, 'B');
+    assert.equal(result.assister, null);
+    assert.equal(result.isOwnGoal, false);
+});
+
+test('a run of defender-only proximity deflections still preserves the recent attacker', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    e.recordTouch(touch(P.D, 1200, 'proximity'));
+    e.recordTouch(touch({ ...P.D, playerId: 5, playerName: 'E' }, 1300, 'proximity'));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1500 });
+
+    assert.equal(result.type, 'goal');
+    assert.equal(result.scorer.name, 'A');
+    assert.equal(result.assister, null);
+    assert.equal(result.isOwnGoal, false);
+});
+
+test('attacker then defender kick is a defender own goal', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    e.recordTouch(touch(P.D, 1200));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1400 });
+
+    assert.equal(result.type, 'own_goal');
+    assert.equal(result.scorer.name, 'D');
+    assert.equal(result.assister, null);
+    assert.equal(result.isOwnGoal, true);
+    assert.equal(result.reason, 'opponent-kick-own-goal');
+});
+
+test('an opponent touch blocks an assist', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    e.recordTouch(touch(P.D, 1200, 'proximity'));
+    e.recordTouch(touch(P.B, 1400));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1600 });
+
+    assert.equal(result.scorer.name, 'B');
+    assert.equal(result.assister, null);
+    assert.equal(result.assistReason, 'assist-blocked-by-opponent');
+});
+
+test('proximity followed by a kick upgrades the current logical touch to kick', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000, 'proximity'));
+    e.recordTouch(touch(P.A, 1050, 'kick'));
+    const touches = e.getTouches();
+
+    assert.equal(touches.length, 1);
+    assert.equal(touches[0].source, 'kick');
+    assert.equal(touches[0].timestamp, 1050);
+});
+
+test('a proximity contact after a kick does not downgrade the current touch', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000, 'kick'));
+    e.recordTouch(touch(P.A, 1050, 'proximity'));
+    const touches = e.getTouches();
+
+    assert.equal(touches.length, 1);
+    assert.equal(touches[0].source, 'kick');
+    assert.equal(touches[0].timestamp, 1050);
+});
+
+test('repeated same-player proximity contacts do not pollute the logical sequence', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000, 'proximity'));
+    e.recordTouch(touch(P.A, 1100, 'proximity'));
+    e.recordTouch(touch(P.A, 1200, 'proximity'));
+    e.recordTouch(touch(P.B, 1300, 'proximity'));
+    e.recordTouch(touch(P.B, 1400, 'proximity'));
+    e.recordTouch(touch(P.B, 1500, 'proximity'));
+    const touches = e.getTouches();
+
+    assert.equal(touches.length, 2);
+    assert.deepEqual(touches.map(entry => entry.playerName), ['A', 'B']);
+    assert.equal(touches[1].timestamp, 1500);
+});
+
+test('a stale touch produces an unknown scorer', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 5000 });
+
+    assert.equal(result.type, 'unknown');
+    assert.equal(result.scorer, null);
+    assert.equal(result.reason, 'no-recent-scoring-touch');
+});
+
+test('a post or crossbar bounce without a player touch preserves the scorer', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1800 });
+
+    assert.equal(result.type, 'goal');
+    assert.equal(result.scorer.name, 'A');
+});
+
+test('reset after a goal clears attribution for the next play', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    e.resolveGoal({ scoringTeam: RED, timestamp: 1200 });
+    e.resetPlay();
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1400 });
+
+    assert.equal(result.type, 'unknown');
+    assert.equal(e.getTouches().length, 0);
+});
+
+test('resetMatch also clears attribution', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 1000));
+    e.resetMatch();
+
+    assert.equal(e.resolveGoal({ scoringTeam: RED, timestamp: 1200 }).type, 'unknown');
+});
+
+test('selects the closest simultaneous proximity contact deterministically', () => {
+    const e = engine();
+    const input = {
+        ballPosition: { x: 0, y: 0 },
+        ballRadius: 10,
+        timestamp: 1000,
+        players: [
+            { id: 2, team: RED, disc: { x: 12, y: 0 }, playerRadius: 5 },
+            { id: 1, team: RED, disc: { x: 11, y: 0 }, playerRadius: 5 },
+        ],
+    };
+
     assert.equal(e.selectClosestContact(input).player.id, 1);
     assert.equal(e.selectClosestContact({ ...input, players: input.players.slice().reverse() }).player.id, 1);
 });
 
-test('player without auth is attributed but safe to pass onward', () => {
-    const e = engine(); e.recordTouch(touch({ ...P.A, playerAuth: null, playerName: 'NoAuth' }, 1000));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1100 });
-    assert.equal(r.scorer.name, 'NoAuth'); assert.equal(r.scorer.auth, null);
-});
-
-test('team snapshot from touch is preserved after later changes', () => {
-    const e = engine(); const player = { ...P.A }; e.recordTouch(touch(player, 1000)); player.playerTeam = BLUE;
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1100 });
-    assert.equal(r.type, 'goal'); assert.equal(r.scorer.team, RED);
-});
-
-test('reset after goal clears previous play', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.resetPlay();
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1200 });
-    assert.equal(r.type, 'unknown');
-});
-
-test('reset match clears previous match', () => {
-    const e = engine(); e.recordTouch(touch(P.A, 1000)); e.resetMatch();
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1200 });
-    assert.equal(r.type, 'unknown');
-});
-
-test('tie contact prefers recent kicker rather than array order', () => {
+test('an effectively tied proximity contact prefers the recent kicker', () => {
     const e = engine();
     e.recordTouch(touch(P.B, 1000, 'kick'));
-    const players = [
-        { id: 1, team: RED, disc: { x: 10, y: 0 }, playerRadius: 5 },
-        { id: 2, team: RED, disc: { x: 10, y: 0 }, playerRadius: 5 },
-    ];
-    const contact = e.selectClosestContact({ ballPosition: { x: 0, y: 0 }, ballRadius: 10, timestamp: 1100, players });
+    const contact = e.selectClosestContact({
+        ballPosition: { x: 0, y: 0 },
+        ballRadius: 10,
+        timestamp: 1100,
+        players: [
+            { id: 1, team: RED, disc: { x: 10, y: 0 }, playerRadius: 5 },
+            { id: 2, team: RED, disc: { x: 10.005, y: 0 }, playerRadius: 5 },
+        ],
+    });
+
     assert.equal(contact.player.id, 2);
 });
 
-test('assist window is measured from passer touch to scorer touch, not to goal time', () => {
+test('a player without auth can still be attributed safely', () => {
+    const e = engine();
+    e.recordTouch(touch({ ...P.A, playerAuth: null, playerName: 'NoAuth' }, 1000));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1100 });
+
+    assert.equal(result.scorer.name, 'NoAuth');
+    assert.equal(result.scorer.auth, null);
+});
+
+test('team identity is snapshotted at touch time', () => {
+    const e = engine();
+    const player = { ...P.A };
+    e.recordTouch(touch(player, 1000));
+    player.playerTeam = BLUE;
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1100 });
+
+    assert.equal(result.type, 'goal');
+    assert.equal(result.scorer.team, RED);
+});
+
+test('an opponent proximity touch without a recent scoring-team touch stays unknown', () => {
+    const e = engine();
+    e.recordTouch(touch(P.D, 1000, 'proximity'));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1200 });
+
+    assert.equal(result.type, 'unknown');
+    assert.equal(result.scorer, null);
+    assert.equal(result.isOwnGoal, false);
+});
+
+test('assist window is measured from passer touch to scorer touch', () => {
     const e = engine({ assistTimeWindowMs: 3000 });
     e.recordTouch(touch(P.A, 1000));
     e.recordTouch(touch(P.B, 3500));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 4300 });
-    assert.equal(r.scorer.name, 'B');
-    assert.equal(r.assister.name, 'A');
-    assert.equal(r.assistReason, 'assist-found');
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 4300 });
+
+    assert.equal(result.assister.name, 'A');
+    assert.equal(result.assistReason, 'assist-found');
 });
 
-test('assist expires when passer to scorer touch exceeds the assist window', () => {
+test('assist expires when passer to scorer touch exceeds the window', () => {
     const e = engine({ assistTimeWindowMs: 3000 });
     e.recordTouch(touch(P.A, 1000));
     e.recordTouch(touch(P.B, 4500));
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 4600 });
-    assert.equal(r.scorer.name, 'B');
-    assert.equal(r.assister, null);
-    assert.equal(r.assistReason, 'assist-expired');
-});
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 4600 });
 
-test('proximity followed by kick updates the last touch instead of losing the kick', () => {
-    const e = engine();
-    assert.equal(e.recordTouch(touch(P.A, 1000, 'proximity')), true);
-    assert.equal(e.recordTouch(touch(P.A, 1050, 'kick')), true);
-    const history = e.getTouches();
-    assert.equal(history.length, 1);
-    assert.equal(history[0].source, 'kick');
-    assert.equal(history[0].timestamp, 1050);
-    const r = e.resolveGoal({ scoringTeam: RED, timestamp: 1100 });
-    assert.equal(r.scorer.name, 'A');
+    assert.equal(result.scorer.name, 'B');
+    assert.equal(result.assister, null);
+    assert.equal(result.assistReason, 'assist-expired');
 });

--- a/tests/goal-attribution.test.mjs
+++ b/tests/goal-attribution.test.mjs
@@ -58,6 +58,21 @@ test('repeated scorer touches do not destroy an assist', () => {
     assert.equal(e.getTouches().length, 2);
 });
 
+test('a long scorer dribble preserves the assist from the takeover transition', () => {
+    const e = engine({ assistTimeWindowMs: 3000 });
+    e.recordTouch(touch(P.A, 1000));
+    e.recordTouch(touch(P.B, 1500));
+    e.recordTouch(touch(P.B, 2200, 'proximity'));
+    e.recordTouch(touch(P.B, 3000, 'proximity'));
+    e.recordTouch(touch(P.B, 4000, 'proximity'));
+    e.recordTouch(touch(P.B, 4050, 'proximity'));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 4100 });
+
+    assert.equal(result.scorer.name, 'B');
+    assert.equal(result.assister.name, 'A');
+    assert.equal(result.assistReason, 'assist-found');
+});
+
 test('does not award a self-assist', () => {
     const e = engine();
     e.recordTouch(touch(P.B, 1000));
@@ -108,17 +123,45 @@ test('a run of defender-only proximity deflections still preserves the recent at
     assert.equal(result.isOwnGoal, false);
 });
 
-test('attacker then defender kick is a defender own goal', () => {
+test('a recent defender kick is a defender own goal', () => {
     const e = engine();
-    e.recordTouch(touch(P.A, 1000));
-    e.recordTouch(touch(P.D, 1200));
-    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1400 });
+    e.recordTouch(touch(P.A, 900));
+    e.recordTouch(touch(P.D, 1800));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1900 });
 
     assert.equal(result.type, 'own_goal');
     assert.equal(result.scorer.name, 'D');
     assert.equal(result.assister, null);
     assert.equal(result.isOwnGoal, true);
     assert.equal(result.reason, 'opponent-kick-own-goal');
+});
+
+test('an old defender kick is not refreshed by a later proximity contact', () => {
+    const e = engine();
+    e.recordTouch(touch(P.D, 1000, 'kick'));
+    e.recordTouch(touch(P.D, 1800, 'proximity'));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1900 });
+    const [defenderTouch] = e.getTouches();
+
+    assert.equal(result.type, 'unknown');
+    assert.equal(result.isOwnGoal, false);
+    assert.equal(defenderTouch.firstTouchTimestamp, 1000);
+    assert.equal(defenderTouch.lastTouchTimestamp, 1800);
+    assert.equal(defenderTouch.lastKickTimestamp, 1000);
+});
+
+test('an old defender kick followed by proximity remains a deflection when a recent attacker exists', () => {
+    const e = engine();
+    e.recordTouch(touch(P.A, 900, 'kick'));
+    e.recordTouch(touch(P.D, 1000, 'kick'));
+    e.recordTouch(touch(P.D, 1800, 'proximity'));
+    const result = e.resolveGoal({ scoringTeam: RED, timestamp: 1900 });
+
+    assert.equal(result.type, 'goal');
+    assert.equal(result.scorer.name, 'A');
+    assert.equal(result.assister, null);
+    assert.equal(result.isOwnGoal, false);
+    assert.equal(result.reason, 'opponent-proximity-deflection');
 });
 
 test('an opponent touch blocks an assist', () => {
@@ -142,17 +185,24 @@ test('proximity followed by a kick upgrades the current logical touch to kick', 
     assert.equal(touches.length, 1);
     assert.equal(touches[0].source, 'kick');
     assert.equal(touches[0].timestamp, 1050);
+    assert.equal(touches[0].firstTouchTimestamp, 1000);
+    assert.equal(touches[0].lastTouchTimestamp, 1050);
+    assert.equal(touches[0].lastKickTimestamp, 1050);
 });
 
-test('a proximity contact after a kick does not downgrade the current touch', () => {
+test('same-player proximity, kick, and proximity keep independent logical timing', () => {
     const e = engine();
-    e.recordTouch(touch(P.A, 1000, 'kick'));
-    e.recordTouch(touch(P.A, 1050, 'proximity'));
+    e.recordTouch(touch(P.A, 1000, 'proximity'));
+    e.recordTouch(touch(P.A, 1050, 'kick'));
+    e.recordTouch(touch(P.A, 1100, 'proximity'));
     const touches = e.getTouches();
 
     assert.equal(touches.length, 1);
     assert.equal(touches[0].source, 'kick');
-    assert.equal(touches[0].timestamp, 1050);
+    assert.equal(touches[0].firstTouchTimestamp, 1000);
+    assert.equal(touches[0].lastTouchTimestamp, 1100);
+    assert.equal(touches[0].lastKickTimestamp, 1050);
+    assert.equal(touches[0].timestamp, 1100);
 });
 
 test('repeated same-player proximity contacts do not pollute the logical sequence', () => {


### PR DESCRIPTION
## Summary

Simplifies goal attribution around a small logical touch state inspired by the proven HaxBall headless-host approach of tracking the current player and the previous different player, while preserving our stronger `kick` vs `proximity` distinction.

### Changes
- Replace the long touch-history model with `currentTouch` / `previousDifferentTouch` plus a small per-team lookup used to recover an attacker through a defensive deflection.
- Collapse repeated touches by the same player instead of polluting attribution history.
- Preserve `kick` as stronger evidence than `proximity`; a later proximity sample cannot downgrade a kick.
- Keep normal scorer/assist attribution simple: latest scoring-team player scores, previous different scoring-team player can assist.
- Treat opponent `proximity` as a deflection rather than an automatic own goal.
- Block assists across an opponent deflection.
- Require an opponent `kick` for the conservative own-goal classification.
- Return `unknown` when there is no sufficiently recent scoring touch instead of fabricating a scorer.
- Keep deterministic closest-contact / recent-kicker tie-breaking behavior.

## Motivation

The previous attribution engine was producing too many own goals in real matches because any recent opponent contact detected on `onGameTick` could become the latest touch and therefore be classified as an own goal. In practice, small blocks and deflections were frequently stealing goals from attackers.

Example fixed by this PR:

```text
RED attacker kick
BLUE defender proximity contact
goal RED

=> RED attacker goal
=> no assist
=> not an own goal
```

A stronger defensive action still produces an own goal:

```text
RED attacker kick
BLUE defender kick
goal RED

=> own goal by BLUE defender
```

## Tests

`tests/goal-attribution.test.mjs` was substantially expanded/updated to cover normal goals, assists, repeated touches, deflections, conservative own goals, stale attribution, resets, kick/proximity precedence, deterministic contact selection and the false-own-goal regressions.